### PR TITLE
Fixed a typo in req.snippet

### DIFF
--- a/snippets/javascript/req.snippet
+++ b/snippets/javascript/req.snippet
@@ -1,2 +1,1 @@
-var $1 = require ('${1:sys}')
-
+var ${1:moodule_name} = require ('$1')


### PR DESCRIPTION
The original wasn't working in my MacVim (Build 65). I figured some other people may have been having a similar problem.
